### PR TITLE
Self-closing Tag Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,17 +93,21 @@
                 case ">":
                     if(currentState === TAG_START || currentState === TAG_ATTRIBUTES){
                         currentState = NOT_TAG;
-                        if(currentTag.toLowerCase() === "/p"){
+                        currentTag = currentTag.toLowerCase();
+                        if(currentTag === "/p"){
                             paragraphCounter++;
                             if(options.StripHTML){
                                 truncatedText += " ";
                             }
                         }
 
-                        if(currentTag.indexOf("/") === -1){
-                            tagStack.push(currentTag);
-                        }else if(selfClosingTags.indexOf(currentTag) === -1){
-                            tagStack.pop();
+                        // Ignore self-closing tags.
+                        if ((selfClosingTags.indexOf(currentTag) === -1) && (selfClosingTags.indexOf(currentTag + '/') === -1)) {
+                            if(currentTag.indexOf("/") >= 0){
+                                tagStack.pop();
+                            } else {
+                                tagStack.push(currentTag);
+                            }
                         }
                     }
                     if(!options.StripHTML){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truncatise",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Truncate HTML based on characters, words or paragraphs. Has the ability to strip tags.",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -167,6 +167,11 @@ describe("Handling tags", function(){
 		truncatise("<p>This <a href=\"/\">is a long paragraph</a> that I intend to truncate.</p>",{TruncateLength: 2, TruncateBy : "words", StripHTML : false, Suffix : ''})
             .should.equal("<p>This <a href=\"/\">is</a></p>");
 	});
+
+    it("should not append self-closing br tags to the end of the string",function(){
+		truncatise("<p>This<br>handles<br></p>",{TruncateLength: 2, TruncateBy : "words", StripHTML : false, Suffix : ''})
+            .should.equal("<p>This<br>handles<br></p>");
+	});
 });
 
 describe("Performance testing",function() {


### PR DESCRIPTION
Added fix to ensure that self-closing tags in the content are not appended to the truncated content.